### PR TITLE
Trigger docs workflow after contributor update

### DIFF
--- a/.github/workflows/contributor-generator.yml
+++ b/.github/workflows/contributor-generator.yml
@@ -33,3 +33,11 @@ jobs:
         token: ${{ secrets.FA_TOKEN }}
         path: README.md
         body: '${{steps.contributors.outputs.htmlList}}'
+        
+    - name: Trigger docs workflow
+      run: |
+        curl -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.FA_TOKEN }}" \
+          https://api.github.com/repos/STICKnoLOGIC/First-Accord-Docs/dispatches \
+          -d '{"event_type":"update_contributors","client_payload":{"htmlList":"${{ steps.contributors.outputs.htmlList }}"}}'


### PR DESCRIPTION
Adds a step to the contributor-generator workflow to trigger the First-Accord-Docs workflow via GitHub API, passing the updated contributors list. This ensures documentation stays in sync with contributor changes.