### PR TITLE
Update contributor workflow to use base64 payload

### DIFF
--- a/.github/workflows/contributor-generator.yml
+++ b/.github/workflows/contributor-generator.yml
@@ -2,7 +2,7 @@ name: Readme Generator - Contributors
 
 on:
   schedule:
-    - cron: "0 */2 * * *"
+    - cron: "* */2 * * *"
   workflow_dispatch:
 
 permissions:
@@ -36,11 +36,12 @@ jobs:
         
     - name: Trigger docs workflow
       run: |
-         htmlList="${{ steps.contributors.outputs.htmlList }}"
-         jq -n --arg htmlList "$htmlList" \
-         '{"event_type":"update_contributors","client_payload":{"htmlList":$htmlList}}' > payload.json
+        htmlList="${{ steps.contributors.outputs.htmlList }}"
+        htmlListBase64=$(echo "$htmlList" | base64 -w 0)
+        jq -n --arg htmlListBase64 "$htmlListBase64" \
+          '{"event_type":"update_contributors","client_payload":{"htmlListBase64":$htmlListBase64}}' > payload.json
 
-         curl -X POST \
+        curl -X POST \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ secrets.FA_WF }}" \
           https://api.github.com/repos/STICKnoLOGIC/First-Accord-Docs/dispatches \


### PR DESCRIPTION
Changed the cron schedule to trigger every minute within each 2-hour window. Contributor HTML list is now encoded in base64 and sent as 'htmlListBase64' in the workflow dispatch payload for improved data handling.