### PR TITLE
Fix shell variable assignment in workflow

### DIFF
--- a/.github/workflows/contributor-generator.yml
+++ b/.github/workflows/contributor-generator.yml
@@ -36,7 +36,10 @@ jobs:
         
     - name: Trigger docs workflow
       run: |
-        htmlList=`${{ steps.contributors.outputs.htmlList }}`
+        htmlList=$(cat <<'EOF'
+        ${{ steps.contributors.outputs.htmlList }}
+        EOF
+        )
         htmlListBase64=$(echo "$htmlList" | base64 -w 0)
         jq -n --arg htmlListBase64 "$htmlListBase64" \
           '{"event_type":"update_contributors","client_payload":{"htmlListBase64":$htmlListBase64}}' > payload.json


### PR DESCRIPTION
Replaces backtick command substitution with a heredoc for assigning htmlList in the contributor-generator workflow, improving reliability and handling multiline output.